### PR TITLE
Fix for Windows insider build 20246

### DIFF
--- a/clink/shared/hook.c
+++ b/clink/shared/hook.c
@@ -188,8 +188,6 @@ static char* write_trampoline_out(char* write, void* to_hook, void* hook)
     const int rel_jmp_size = 5;
     int offset = 0;
     char* patch = (char*)to_hook;
-    unsigned char failed_bytes[125];
-    memset(failed_bytes, 0, 125);
 
     // Scan backwards for a nop slide or int3 block to patch into.
     int viable_bytes = 0;
@@ -199,11 +197,7 @@ static char* write_trampoline_out(char* write, void* to_hook, void* hook)
         offset++;
 
         unsigned char c = *patch;
-        if (offset > 125 || c == 0xc3){
-            // if c is '0xc33, we've hit a RET, which likely means that we're in another function.
-            // Skip the rest.
-            if (c == 0xc3)
-                LOG_INFO("Hit RET");
+        if (offset > 135){
             LOG_INFO("No nop slide or int3 block detected nearby prior to hook target, checked %d prior bytes", offset-1);
             LOG_INFO("Now checking bytes after hook target");
             // reset for checking forwards
@@ -222,7 +216,7 @@ static char* write_trampoline_out(char* write, void* to_hook, void* hook)
         patch++;
         offset--;
 
-        if (offset < -125)
+        if (offset < -135)
         {
             LOG_INFO("No nop slide or int3 block detected nearby after hook target, checked %d later bytes", (-1 * (offset+1)));
             return NULL;

--- a/clink/shared/hook.c
+++ b/clink/shared/hook.c
@@ -197,7 +197,7 @@ static char* write_trampoline_out(char* write, void* to_hook, void* hook)
         offset++;
 
         unsigned char c = *patch;
-        if (offset > 135){
+        if (offset > 127){
             LOG_INFO("No nop slide or int3 block detected nearby prior to hook target, checked %d prior bytes", offset-1);
             LOG_INFO("Now checking bytes after hook target");
             // reset for checking forwards
@@ -216,7 +216,7 @@ static char* write_trampoline_out(char* write, void* to_hook, void* hook)
         patch++;
         offset--;
 
-        if (offset < -135)
+        if (offset < -131)
         {
             LOG_INFO("No nop slide or int3 block detected nearby after hook target, checked %d later bytes", (-1 * (offset+1)));
             return NULL;
@@ -234,6 +234,8 @@ static char* write_trampoline_out(char* write, void* to_hook, void* hook)
         offset += 4;
         patch -= 4;
     }
+    
+    LOG_INFO("Patching at offset %d", -1 * (offset));
 
     // Patch the API.
     patch = write_rel_jmp(patch, write);


### PR DESCRIPTION
See https://github.com/mridgers/clink/issues/543#issuecomment-720810444

Remove restriction on hitting other functions,
increase search size to 135 bytes.